### PR TITLE
Django 3.x compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,18 @@
 branches: {only: [master]}
 
+dist: xenial
 sudo: false
 cache: pip
 language: python
 
 matrix:
   include:
-    - {env: TOXENV=style, python: "3.4"}
-    - python: "2.7"
-    - python: "3.4"
-    - python: "3.5"
+    - {env: TOXENV=style, python: "3.6"}
     - python: "3.6"
+    - python: "3.7"
 
 install:
-  - pip install tox-travis
-  - pip install codecov
-  - pip install -U pip setuptools
+  - pip install -U pip codecov setuptools tox-travis
 
 script: tox -v
 

--- a/analog/exceptions.py
+++ b/analog/exceptions.py
@@ -8,7 +8,7 @@ class UnknownLogKind(ValueError):
         :param value: The invalid kind value passed in.
         """
         message = "Unknown log entry kind %r" % value
-        super(UnknownLogKind, self).__init__(message)
+        super().__init__(message)
 
 
 class NoExtraField(ValueError):

--- a/analog/models.py
+++ b/analog/models.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from django.conf import settings
 from django.db import models
 from django.utils.encoding import force_text
@@ -56,7 +54,7 @@ class BaseLogEntry(models.Model):
     def save(self, *args, **kwargs):
         if self.pk:
             raise ValueError("%r objects may not be modified" % self.__class__)
-        super(BaseLogEntry, self).save(*args, **kwargs)
+        super().save(*args, **kwargs)
 
     @classmethod
     def add_log_entry(

--- a/analog/models.py
+++ b/analog/models.py
@@ -3,18 +3,17 @@ from __future__ import unicode_literals
 from django.conf import settings
 from django.db import models
 from django.utils.encoding import force_text
-from django.utils.six import integer_types, string_types
 
 from analog.exceptions import NoExtraField, UnknownLogKind
 from analog.settings import KIND_IDS, KIND_LABELS, KINDS
 
 
 def _map_kind(kind):
-    if isinstance(kind, string_types):
+    if isinstance(kind, str):
         if kind not in KINDS:
             raise UnknownLogKind(kind)
         kind = KINDS[kind]
-    assert isinstance(kind, integer_types)
+    assert isinstance(kind, int)
     if kind not in KIND_IDS:
         raise UnknownLogKind(kind)
     return kind

--- a/analog/settings.py
+++ b/analog/settings.py
@@ -1,5 +1,4 @@
 from django.conf import settings
-from django.utils.six import string_types
 from django.utils.translation import ugettext_lazy as _
 
 _DEFAULT_KINDS = {
@@ -33,7 +32,7 @@ def _get_kind_labels(kinds):
         for (mnemonic, label) in kind_labels.items()
     )
     for key in list(kind_labels):
-        if isinstance(kind_labels[key], string_types):
+        if isinstance(kind_labels[key], str):
             kind_labels[key] = _(kind_labels[key])
     return kind_labels
 

--- a/analog/settings.py
+++ b/analog/settings.py
@@ -27,10 +27,10 @@ _DEFAULT_KIND_LABELS = {
 def _get_kind_labels(kinds):
     kind_labels = _DEFAULT_KIND_LABELS.copy()
     kind_labels.update(getattr(settings, "ANALOG_KIND_LABELS", {}))
-    kind_labels = dict(
-        (KINDS.get(mnemonic, mnemonic), label)
+    kind_labels = {
+        KINDS.get(mnemonic, mnemonic): label
         for (mnemonic, label) in kind_labels.items()
-    )
+    }
     for key in list(kind_labels):
         if isinstance(kind_labels[key], str):
             kind_labels[key] = _(kind_labels[key])

--- a/analog/util.py
+++ b/analog/util.py
@@ -2,7 +2,7 @@ from analog.exceptions import UnknownLogKind
 from analog.settings import KINDS
 
 
-class LogEntryKindMap(object):
+class LogEntryKindMap:
     """
     A helper class for transitioning old code.
 

--- a/analog_tests/test_analog.py
+++ b/analog_tests/test_analog.py
@@ -19,7 +19,8 @@ def qs_last(qs):  # Compatibility shim for old Djangos
         return list(qs.all())[-1]
 
 
-@pytest.fixture(scope="module", params=["free", "target"])
+@pytest.fixture(params=["free", "target"])
+@pytest.mark.django_db
 def target_object(request):
     if request.param == "target":
         return LoggedModel.objects.create()
@@ -38,7 +39,8 @@ def target_object(request):
 def test_model_sanity():
     log_entry_model = define_log_model(RandomModel)
     assert log_entry_model.__module__ == RandomModel.__module__
-    assert log_entry_model._meta.get_field("target").rel.to is RandomModel
+    target_field = log_entry_model._meta.get_field("target")
+    assert target_field.related_model is RandomModel
     try:
         rel = RandomModel.log_entries.related
         # TODO: Assert here too?

--- a/requirements-stylecheck.txt
+++ b/requirements-stylecheck.txt
@@ -2,14 +2,17 @@
 #
 #   prequ update
 #
-flake8==3.4.1
-flake8-isort==2.2.2
-flake8-polyfill==1.0.1
-flake8-print==2.0.2
-isort==4.2.15
+entrypoints==0.3
+flake8==3.7.9
+flake8-isort==2.9.1
+flake8-polyfill==1.0.2
+flake8-print==3.1.4
+isort[pyproject]==4.3.21
 mccabe==0.6.1
 pep257==0.7.0
-pep8-naming==0.4.1
-pycodestyle==2.3.1
-pyflakes==1.5.0
-testfixtures==5.2.0
+pep8-naming==0.10.0
+pycodestyle==2.5.0
+pyflakes==2.1.1
+six==1.14.0
+testfixtures==6.14.0
+toml==0.10.0

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -2,10 +2,17 @@
 #
 #   prequ update
 #
-coverage==4.4.1
-py==1.4.34
-pytest==3.2.2
-pytest-cov==2.5.1
-pytest-django==3.1.2
-pytest-sugar==0.9.0
-termcolor==1.1.0
+attrs==19.3.0
+coverage==5.1
+importlib-metadata==1.6.0
+more-itertools==8.2.0
+packaging==20.3
+pluggy==0.13.1
+py==1.8.1
+pyparsing==2.4.7
+pytest==5.4.1
+pytest-cov==2.8.1
+pytest-django==3.9.0
+six==1.14.0
+wcwidth==0.1.9
+zipp==3.1.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,7 +51,6 @@ requirements-stylecheck =
     pep8-naming
 
 requirements-test =
-    pytest>=3.0.0
+    pytest>=5.0.0
     pytest-cov
-    pytest-django>=3.0.0
-    pytest-sugar
+    pytest-django

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = django-analog
-version = 1.0.0.post+gitver
+version = 1.1.0.pre+gitver
 description = Simple per-model log models for Django apps
 long_description = file: README.rst
 keywords = django, logging

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,7 @@ multi_line_output = 4
 skip=.tox,dist,venv,docs
 not_skip = __init__.py
 known_first_party=analog
-known_third_party=django,pytest,six
+known_third_party=django,pytest
 
 [prequ]
 requirements-stylecheck =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = style,py{36,37}-django{2x,3x}
+envlist = style,py{36,37}-django{22,30,31}
 skip_missing_interpreters = true
 
 [testenv]
@@ -7,8 +7,9 @@ commands =
     py.test -ra -v --strict --doctest-modules \
         {posargs:--cov=analog analog_tests analog}
 deps =
-    django2x: Django>=2.0,<3.0
-    django3x: Django>=3.0,<4.0
+    django22: Django~=2.2
+    django30: Django~=3.0
+    django31: Django~=3.1
     -rrequirements-test.txt
 
 [testenv:style]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = style,py{27,34,35,36}-django{18,19,110,111}
+envlist = style,py{36,37}-django{2x,3x}
 skip_missing_interpreters = true
 
 [testenv]
@@ -7,14 +7,12 @@ commands =
     py.test -ra -v --strict --doctest-modules \
         {posargs:--cov=analog analog_tests analog}
 deps =
-    django18: Django>=1.8,<1.9
-    django19: Django>=1.9,<1.10
-    django110: Django>=1.10,<1.11
-    django111: Django>=1.11,<1.12
+    django2x: Django>=2.0,<3.0
+    django3x: Django>=3.0,<4.0
     -rrequirements-test.txt
 
 [testenv:style]
 skip_install = True
-basepython = python3.4
+basepython = python3.6
 deps = -rrequirements-stylecheck.txt
 commands = flake8 {posargs}


### PR DESCRIPTION
* Drop Python 2 compat (and run `pyupgrade` to remove Py2isms)
* Remove usages of `six`
* Change some technicalities in tests

---

I'm not sure what's gotten Travis's knickers in a twist. Tests pass fine for me locally:

```
$ git clean -fdx
$ ve 3 django-analog
created virtual environment in 272ms CPython3Posix
$ v django-analog
Activating /Users/akx/envs/django-analog
$ pip install tox
$ tox
[.... snip ....]
SKIPPED:  style: InterpreterNotFound: python3.6
SKIPPED:  py36-django2x: InterpreterNotFound: python3.6
SKIPPED:  py36-django3x: InterpreterNotFound: python3.6
  py37-django2x: commands succeeded
  py37-django3x: commands succeeded
  congratulations :)
$
```