### PR TITLE
Correct the "approximate" version specs in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,9 +7,9 @@ commands =
     py.test -ra -v --strict --doctest-modules \
         {posargs:--cov=analog --cov-report=xml analog_tests analog}
 deps =
-    django22: Django~=2.2
-    django30: Django~=3.0
-    django31: Django~=3.1
+    django22: Django~=2.2.0
+    django30: Django~=3.0.0
+    django31: Django~=3.1.0
     -rrequirements-test.txt
 
 [testenv:style]


### PR DESCRIPTION
Against the Principle of Least Astonishment, `~=3.0` may install 3.1; one needs to add the patch version too to pin things correctly.